### PR TITLE
fix: SyncClient memory leak, handling connect() errors

### DIFF
--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -62,6 +62,7 @@ int SyncClient::connect(IPAddress ip, uint16_t port){
     return 0;
   _client = new AsyncClient();
   _client->onConnect([](void *obj, AsyncClient *c){ ((SyncClient*)(obj))->_onConnect(c); }, this);
+  _attachCallbacks_Disconnect();
 #if ASYNC_TCP_SSL_ENABLED
   if(_client->connect(ip, port, secure)){
 #else

--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -83,6 +83,7 @@ int SyncClient::connect(const char *host, uint16_t port){
     return 0;
   _client = new AsyncClient();
   _client->onConnect([](void *obj, AsyncClient *c){ ((SyncClient*)(obj))->_onConnect(c); }, this);
+  _attachCallbacks_Disconnect();
 #if ASYNC_TCP_SSL_ENABLED
   if(_client->connect(host, port, secure)){
 #else
@@ -191,14 +192,22 @@ void SyncClient::_onConnect(AsyncClient *c){
     delete b;
   }
   _tx_buffer = new cbuf(_tx_buffer_size);
-  _attachCallbacks();
+  _attachCallbacks_AfterConnected();
 }
 
 void SyncClient::_attachCallbacks(){
+  _attachCallbacks_Disconnect();
+  _attachCallbacks_AfterConnected();
+}
+
+void SyncClient::_attachCallbacks_AfterConnected(){
   _client->onAck([](void *obj, AsyncClient* c, size_t len, uint32_t time){ ((SyncClient*)(obj))->_sendBuffer(); }, this);
-  _client->onDisconnect([](void *obj, AsyncClient* c){ ((SyncClient*)(obj))->_onDisconnect(); delete c; }, this);
   _client->onData([](void *obj, AsyncClient* c, void *data, size_t len){ ((SyncClient*)(obj))->_onData(data, len); }, this);
   _client->onTimeout([](void *obj, AsyncClient* c, uint32_t time){ c->close(); }, this);
+}
+
+void SyncClient::_attachCallbacks_Disconnect(){
+  _client->onDisconnect([](void *obj, AsyncClient* c){ ((SyncClient*)(obj))->_onDisconnect(); delete c; }, this);
 }
 
 size_t SyncClient::write(uint8_t data){

--- a/src/SyncClient.h
+++ b/src/SyncClient.h
@@ -39,6 +39,8 @@ class SyncClient: public Client {
     void _onConnect(AsyncClient *c);
     void _onDisconnect();
     void _attachCallbacks();
+    void _attachCallbacks_Disconnect();
+    void _attachCallbacks_AfterConnected();
 
   public:
     SyncClient(size_t txBufLen = 1460);


### PR DESCRIPTION
Hi me-no-dev! Thanks a lot for your async library.

I just found a bug, which occurs e.g. when the connect() call times out. It gets stuck in an infinite loop [here](https://github.com/me-no-dev/ESPAsyncTCP/blob/master/src/SyncClient.cpp#L92), so I think that we only need to attach the onDisconnect callback before calling _client->connect(). Of course feel free to rename the new methods as you wish :o)

You can reproduce the bug in the SyncClient example by setting "localhost" with a port without a web server (e.g. localhost:8181). You would expect to see the "Connect Failed" message, but it will not get there.

Cheers,
Michal