### PR TITLE
guard ASYNC_TCP_SSL_ENABLED

### DIFF
--- a/src/async_config.h
+++ b/src/async_config.h
@@ -1,7 +1,10 @@
 #ifndef LIBRARIES_ESPASYNCTCP_SRC_ASYNC_CONFIG_H_
 #define LIBRARIES_ESPASYNCTCP_SRC_ASYNC_CONFIG_H_
 
+#ifndef ASYNC_TCP_SSL_ENABLED
 #define ASYNC_TCP_SSL_ENABLED 0
+#endif
+
 #define ASYNC_TCP_DEBUG(...) //ets_printf(__VA_ARGS__)
 #define TCP_SSL_DEBUG(...) //ets_printf(__VA_ARGS__)
 


### PR DESCRIPTION
so we can enable it with build script by specifying
`-DASYNC_TCP_SSL_ENABLED=1`.