### PR TITLE
Add basic ESP32 support

### DIFF
--- a/examples/SyncClient/SyncClient.ino
+++ b/examples/SyncClient/SyncClient.ino
@@ -1,10 +1,16 @@
 #ifdef ESP8266
-#include <ESP8266WiFi.h>
-#include <ESP8266mDNS.h>
-#include <ArduinoOTA.h>
+  #include <ESP8266WiFi.h>
+  #include <ESP8266mDNS.h>
+#elif ESP31B
+  #include <ESP31BWiFi.h>
+#elif ESP32
+  #include <WiFi.h>
+  #include <ESPmDNS.h>
 #else
-#include <ESP31BWiFi.h>
+  #error "Unsupported platform."
 #endif
+
+#include <ArduinoOTA.h>
 #include "ESPAsyncTCP.h"
 #include "SyncClient.h"
 
@@ -20,9 +26,7 @@ void setup(){
   }
   Serial.printf("WiFi Connected!\n");
   Serial.println(WiFi.localIP());
-#ifdef ESP8266
   ArduinoOTA.begin();
-#endif
   
   SyncClient client;
   if(!client.connect("www.google.com", 80)){
@@ -48,7 +52,5 @@ void setup(){
 }
 
 void loop(){
-#ifdef ESP8266
   ArduinoOTA.handle();
-#endif
 }

--- a/src/ESPAsyncTCPbuffer.cpp
+++ b/src/ESPAsyncTCPbuffer.cpp
@@ -24,7 +24,12 @@
 
 
 #include <Arduino.h>
+
+#ifdef ESP8266
 #include <debug.h>
+#elif ESP32
+#define panic abort
+#endif
 
 #include "ESPAsyncTCPbuffer.h"
 


### PR DESCRIPTION
Hi, I've patched up the code to get it running with the current Arduino-ESP32. It works both on ESP8266 and ESP32.
Apparently there are deeper issues with LwIP and etc for it to be running properly, but this gets the awesome ESPAsyncWebServer running, so I'm sharing my code.

At this time Arduino-ESP32 [1] as well as Arduino in general does not support IPv6 in its IPAddress class, thus the API is limited to using IPv4 addresses.
[1] - https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/IPAddress.h#L33