### PR TITLE
Fix improper _recv() callback return when ssl layer returned SSL_CLOSE_NOTIFY

### DIFF
--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -395,7 +395,7 @@ err_t AsyncClient::_recv(tcp_pcb* pcb, pbuf* pb, err_t err) {
         ASYNC_TCP_DEBUG("_recv err: %d\n", read_bytes);
         _close();
       }
-      return read_bytes;
+      //return read_bytes;
     }
     return ERR_OK;
   }

--- a/src/tcp_axtls.c
+++ b/src/tcp_axtls.c
@@ -406,6 +406,7 @@ int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p) {
   } while (p->tot_len - fd_data->pbuf_offset > 0);
 
   tcp_recved(tcp, p->tot_len);
+  fd_data->tcp_pbuf = NULL;
   pbuf_free(p);
 
   return total_bytes;

--- a/src/tcp_axtls.h
+++ b/src/tcp_axtls.h
@@ -40,6 +40,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include "include/ssl.h"
 
 #define ERR_TCP_SSL_INVALID_SSL           -101


### PR DESCRIPTION
With AsynClient, when remote initiated disconnect, tcp_ssl_read() will return SSL_CLOSE_NOTIFY.
However, at this moment, the pbuf has already been freed, and thus the _recv() callback should return ERR_OK so that LwIP can properly discard the buffer reference.

Otherwise, LwIP2 will think the data is not consumed, and attempt to maintain it in refused_data, and ultimately cause a double free and crash later.

On LwIP1, this is still an error, but it is likely to not cause any problem because LwIP1 does not attempt to maintain the unconsumed refused_data, instead it just print an assert message and overwrite the pointer with a new piece of data.

For the changes, there are three lines, only one line in src/ESPAsyncTCP.cpp directly related to this bug;
The other two lines are nice-to-have:
The second line in src/tcp_axtls.c is there just to keep a peace of mind;
The thrid line in src/tcp_axtls.h solves C99 compiler complaint of unknown bool type.