### PR TITLE
Add reuse flag

### DIFF
--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -1116,6 +1116,9 @@ void AsyncServer::begin(){
   if (!pcb){
     return;
   }
+  
+  // Reuse freed socket.
+  pcb->so_options |= SOF_REUSEADDR;
 
   tcp_setprio(pcb, TCP_PRIO_MIN);
   ip_addr_t local_addr;


### PR DESCRIPTION
Let's say, for example: without of this flag it's can't start asyncwebserver on 80 port after wifimanager(also on 80) is shutdowned. But wifimanager still may be started, because in "WiFiServer.cpp" of ESP8266WiFi lib it's creates tcp_pcb with "SOF_REUSEADDR" flag.