### PR TITLE
ESPAsyncTCP.h: remove unnecessary semicolon

### DIFF
--- a/src/ESPAsyncTCP.h
+++ b/src/ESPAsyncTCP.h
@@ -31,7 +31,7 @@ extern "C" {
     #include "lwip/init.h"
     #include "lwip/err.h"
     #include "lwip/pbuf.h"
-};
+}
 
 class AsyncClient;
 class AsyncServer;


### PR DESCRIPTION
Fixes a warning when compiling with `-Wpedantic`:

```
.pio/libdeps/nodemcu/ESPAsyncTCP/src/ESPAsyncTCP.h:34:2: warning: extra ';' [-Wpedantic]
   34 | };
      |  ^
```